### PR TITLE
Ignore leading whitespace for regular expression that identifies FILE columns.

### DIFF
--- a/src/ImageSpread.js
+++ b/src/ImageSpread.js
@@ -59,7 +59,7 @@
 
 		//override this.dimensions to include only FILE dimensions
 		this.dimensions = this.dimensions.filter(function(d) {
-			return (/^FILE/).test(d);
+			return (/^\s*FILE/).test(d);
 		});
 		/** @type {boolean} Whether any FILE dimensions exist in the dataset */
 		this.hasFileDimensions = this.dimensions.length != 0;


### PR DESCRIPTION
One of the issues that frequently comes up for me while using Cinema Components is that users have leading and trailing whitespace all over their CSV files.

This PR makes it so leading whitespace is ignore when identifying ``FILE`` columns.

Right now, the substring ``FILE`` must start at the first position.
This allows variants such as
```
x0,x1,    FILE
```